### PR TITLE
Implement puzzle minigame skeleton

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -341,6 +341,7 @@ aria-labelledby="pokedexModalLabel">
                                             <!-- /ko -->
                                             <img style="position: absolute; top: 24px; right: 0px;" class="shadow-icon" src="assets/images/status/shadow.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Shadow"/>
                                             <img style="position: absolute; top: 24px; right: 0px;" class="shadow-icon" src="assets/images/status/purified.svg" data-bind="visible: App.game.party.getPokemon($data.id).shadow == GameConstants.ShadowStatus.Purified"/>
+                                            <img style="position: absolute; bottom: 0; left: 0;" class="puzzle-medal" src="assets/images/currency/contestToken.svg" data-bind="visible: App.game.statistics.pokemonPuzzleSolved[$data.id]() > 0"/>
                                         <!-- /ko -->
                                         <img src="" class="pokedex-pokemon-sprite" data-bind="css: { 'pokemon-not-seen': !PokedexHelper.pokemonSeen($data.id)(), 'pokemon-seen-but-not-caught': !App.game.party.alreadyCaughtPokemonByName(name) && PokedexHelper.pokemonSeen($data.id)() }, attr:{ src: PokemonHelper.getImage($data.id)}">
                                         <!-- ko if: PokedexHelper.pokemonSeen($data.id) -->

--- a/src/components/puzzleModal.html
+++ b/src/components/puzzleModal.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="puzzleModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content text-center">
+            <div class="modal-header">
+                <h5 class="modal-title">Puzzle</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body" data-bind="with: PuzzleController.currentPuzzle">
+                <img data-bind="attr:{src: PokemonHelper.getImage(pokemonId)}" style="max-width:96px" class="mb-2"/>
+                <p data-bind="text: 'Difficulty: ' + difficulty"></p>
+                <button class="btn btn-success" data-bind="click: PuzzleController.solveCurrent">Solve</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/components/puzzleModal.html
+++ b/src/components/puzzleModal.html
@@ -7,10 +7,10 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body" data-bind="with: PuzzleController.currentPuzzle">
+            <div class="modal-body" data-bind="with: App.game.puzzleController.currentPuzzle">
                 <img data-bind="attr:{src: PokemonHelper.getImage(pokemonId)}" style="max-width:96px" class="mb-2"/>
                 <p data-bind="text: 'Difficulty: ' + difficulty"></p>
-                <button class="btn btn-success" data-bind="click: PuzzleController.solveCurrent">Solve</button>
+                <button class="btn btn-success" data-bind="click: App.game.puzzleController.solveCurrent">Solve</button>
             </div>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -520,6 +520,9 @@
 <!-- Dream Orbs Modal -->
 @import "dreamOrbsModal.html"
 
+<!-- Puzzle Modal -->
+@import "puzzleModal.html"
+
 <!-- Dream Orbs Opened Modal -->
 @import "dreamOrbsOpenedModal.html"
 

--- a/src/modules/DataStore/StatisticStore/index.ts
+++ b/src/modules/DataStore/StatisticStore/index.ts
@@ -144,6 +144,7 @@ export default class Statistics implements Saveable {
     shinyPokemonHatched: PokemonStats;
     shadowPokemonCaptured: PokemonStats;
     shadowPokemonDefeated: PokemonStats;
+    pokemonPuzzleSolved: PokemonStats;
     npcTalkedTo: Record<string, KnockoutObservable<number>>;
 
     observables = [
@@ -250,6 +251,7 @@ export default class Statistics implements Saveable {
         'shinyPokemonHatched',
         'shadowPokemonCaptured',
         'shadowPokemonDefeated',
+        'pokemonPuzzleSolved',
         'npcTalkedTo',
         'undergroundToolsUsed',
     ];

--- a/src/modules/TemporaryScriptTypes.ts
+++ b/src/modules/TemporaryScriptTypes.ts
@@ -97,6 +97,7 @@ export type TmpAchievementTrackerType = any;
 export type TmpBattleFrontierType = any;
 export type TmpBattleCafeSaveObjectType = any;
 export type TmpDreamOrbControllerType = any;
+export type TmpPuzzleControllerType = any;
 export type TmpPurifyChamberType = any;
 export type TmpWeatherAppType = any;
 export type TmpZMovesType = any;
@@ -134,6 +135,7 @@ export type TmpGameType = {
     saveReminder: SaveReminder;
     battleCafe: TmpBattleCafeSaveObjectType;
     dreamOrbController: TmpDreamOrbControllerType;
+    puzzleController: TmpPuzzleControllerType;
     purifyChamber: TmpPurifyChamberType;
     weatherApp: TmpWeatherAppType;
     zMoves: TmpZMovesType;

--- a/src/modules/items/ItemList.ts
+++ b/src/modules/items/ItemList.ts
@@ -340,6 +340,7 @@ ItemList.Beige_shard = new TreasureItem('Beige_shard', UndergroundItemValueType.
 ItemList.Slate_shard = new TreasureItem('Slate_shard', UndergroundItemValueType.Shard, 'Slate Shard');
 // Other
 ItemList.Palaeontologist_token = new TreasureItem('Palaeontologist_token', UndergroundItemValueType.Special, 'Palaeontologist Token');
+ItemList.Puzzle_plate = new TreasureItem('Puzzle_plate', UndergroundItemValueType.Special, 'Puzzle Plate');
 
 
 // Pokemon shop items

--- a/src/modules/pokemons/PokemonHelper.ts
+++ b/src/modules/pokemons/PokemonHelper.ts
@@ -161,6 +161,14 @@ export function isGigantamaxForm(pokemonName: PokemonNameType): boolean {
     return pokemonName.startsWith('Gigantamax') || pokemonName.startsWith('Eternamax');
 }
 
+export function isPuzzleSolved(pokemonId: number): boolean {
+    return App.game.statistics.pokemonPuzzleSolved[pokemonId]() > 0;
+}
+
+export function puzzleCatchBonus(pokemonId: number): number {
+    return isPuzzleSolved(pokemonId) ? 5 : 0;
+}
+
 export const getAllShadowPokemon = ko.pureComputed((): Set<PokemonNameType> => {
     return new Set(Object.values(dungeonList).flatMap(d => d.allShadowPokemon()));
 });

--- a/src/modules/puzzles/PokemonPuzzle.ts
+++ b/src/modules/puzzles/PokemonPuzzle.ts
@@ -1,0 +1,13 @@
+import GameHelper from '../GameHelper';
+
+export default class PokemonPuzzle {
+    solved: KnockoutObservable<boolean> = ko.observable(false);
+    constructor(public pokemonId: number, public difficulty: number) {}
+
+    solve() {
+        if (!this.solved()) {
+            this.solved(true);
+            GameHelper.incrementObservable(App.game.statistics.pokemonPuzzleSolved[this.pokemonId]);
+        }
+    }
+}

--- a/src/modules/puzzles/PuzzleController.ts
+++ b/src/modules/puzzles/PuzzleController.ts
@@ -1,7 +1,8 @@
 import PokemonPuzzle from './PokemonPuzzle';
+import { Observable as KnockoutObservable } from 'knockout';
 
 export default class PuzzleController {
-    currentPuzzle: KnockoutObservable<PokemonPuzzle | null> = ko.observable(null);
+    currentPuzzle: KnockoutObservable<PokemonPuzzle | null> = ko.observable<PokemonPuzzle | null>(null);
 
     startPuzzle(pokemonId: number, difficulty: number) {
         this.currentPuzzle(new PokemonPuzzle(pokemonId, difficulty));

--- a/src/modules/puzzles/PuzzleController.ts
+++ b/src/modules/puzzles/PuzzleController.ts
@@ -1,0 +1,19 @@
+import PokemonPuzzle from './PokemonPuzzle';
+
+export default class PuzzleController {
+    currentPuzzle: KnockoutObservable<PokemonPuzzle | null> = ko.observable(null);
+
+    startPuzzle(pokemonId: number, difficulty: number) {
+        this.currentPuzzle(new PokemonPuzzle(pokemonId, difficulty));
+        $('#puzzleModal').modal('show');
+    }
+
+    solveCurrent() {
+        const puzzle = this.currentPuzzle();
+        if (puzzle) {
+            puzzle.solve();
+        }
+        this.currentPuzzle(null);
+        $('#puzzleModal').modal('hide');
+    }
+}

--- a/src/modules/underground/UndergroundItems.ts
+++ b/src/modules/underground/UndergroundItems.ts
@@ -152,3 +152,4 @@ UndergroundItems.addItem(new UndergroundMegaStoneItem(MegaStoneType.Sablenite, 5
 
 // Other
 UndergroundItems.addItem(new UndergroundItem(600, 'Palaeontologist_token', [[0, 0, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1], [0, 0, 1, 1, 1, 1], [0, 0, 1, 1, 1, 0], [0, 0, 0, 1, 1, 0], [0, 0, 0, 1, 1, 1]], 1, UndergroundItemValueType.Special));
+UndergroundItems.addItem(new UndergroundItem(601, 'Puzzle_plate', [[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], 0, UndergroundItemValueType.Special));

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -43,6 +43,7 @@ class Game implements TmpGameType {
     public saveReminder: SaveReminder;
     public battleCafe: BattleCafeSaveObject;
     public dreamOrbController: DreamOrbController;
+    public puzzleController: PuzzleController;
     public purifyChamber: PurifyChamber;
     public weatherApp: WeatherApp;
     public zMoves: ZMoves;
@@ -82,6 +83,7 @@ class Game implements TmpGameType {
         this.saveReminder = new SaveReminder();
         this.battleCafe = new BattleCafeSaveObject();
         this.dreamOrbController = new DreamOrbController();
+        this.puzzleController = new PuzzleController();
         this.purifyChamber = new PurifyChamber();
         this.weatherApp = new WeatherApp();
         this.zMoves = new ZMoves();

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -31,7 +31,7 @@ class PokemonFactory {
         // TODO this monster formula needs to be improved. Preferably with graphs :D
         // Health has a +/- 10% variable based on base health stat compared to the average of the route
         const maxHealth: number = Math.round(PokemonFactory.routeHealth(route, region) * (0.9 + (basePokemon.hitpoints / routeAvgHp(region, route)) / 10));
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, id);
         const exp: number = basePokemon.exp;
         const level: number = this.routeLevel(route, region);
         const money: number = this.routeMoney(route,region);
@@ -139,7 +139,7 @@ class PokemonFactory {
         const shiny = pokemon.shiny ? pokemon.shiny : this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         const gender = this.generateGender(basePokemon.gender.femaleRatio, basePokemon.gender.type);
         const shadow = pokemon.shadow;
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, basePokemon.id);
         return new BattlePokemon(pokemon.name, basePokemon.id, basePokemon.type1, basePokemon.type2, pokemon.maxHealth, pokemon.level, catchRate, exp, new Amount(0, GameConstants.Currency.money), shiny, GameConstants.GYM_GEMS, gender, shadow, EncounterType.trainer);
     }
 
@@ -147,7 +147,7 @@ class PokemonFactory {
         const basePokemon = PokemonHelper.getPokemonByName(name);
         const id = basePokemon.id;
         const maxHealth: number = Math.floor(baseHealth * (1 + (chestsOpened / 5)));
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, id);
         const exp: number = basePokemon.exp;
         const money = 0;
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
@@ -174,7 +174,7 @@ class PokemonFactory {
         const maxHealth: number = Math.floor(baseHealth * (1 + (chestsOpened / 5)) / (isBoss ? 1 : trainerPokemon ** 0.75));
         const exp: number = basePokemon.exp;
         const shiny: boolean = pokemon.shiny ? pokemon.shiny : this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, basePokemon.id);
         // Reward 2% or 5% (boss) of dungeon DT cost when the trainer mons are defeated
         const money = 0;
         const gender = this.generateGender(basePokemon.gender.femaleRatio, basePokemon.gender.type);
@@ -188,7 +188,7 @@ class PokemonFactory {
         const basePokemon = PokemonHelper.getPokemonByName(name);
         const id = basePokemon.id;
         const maxHealth: number = Math.floor(bossPokemon.baseHealth * (1 + (chestsOpened / 5)));
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, id);
         const exp: number = basePokemon.exp;
         const money = 0;
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_DUNGEON);
@@ -210,7 +210,7 @@ class PokemonFactory {
     public static generateTemporaryBattlePokemon(battle: TemporaryBattle, index: number): BattlePokemon {
         const pokemon = battle.getPokemonList()[index];
         const basePokemon = PokemonHelper.getPokemonByName(pokemon.name);
-        const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
+        const catchRate: number = this.catchRateHelper(basePokemon.catchRate, basePokemon.id);
         const encounterType = battle.optionalArgs.isTrainerBattle
             ? EncounterType.trainer
             : App.game.gameState === GameConstants.GameState.dungeon
@@ -262,9 +262,10 @@ class PokemonFactory {
         return Rand.chance(roamingChance);
     }
 
-    private static catchRateHelper(baseCatchRate: number, noVariation = false): number {
+    private static catchRateHelper(baseCatchRate: number, pokemonId?: number, noVariation = false): number {
+        const bonus = pokemonId != undefined ? PokemonHelper.puzzleCatchBonus(pokemonId) : 0;
         const catchVariation = noVariation ? 0 : Rand.intBetween(-3, 3);
-        const catchRateRaw = Math.floor(Math.pow(baseCatchRate, 0.75)) + catchVariation;
+        const catchRateRaw = Math.floor(Math.pow(baseCatchRate + bonus, 0.75)) + catchVariation;
         return GameConstants.clipNumber(catchRateRaw, 0, 100);
     }
 
@@ -387,7 +388,7 @@ class PokemonFactory {
         const pokemon = Rand.fromWeightedArray(availablePokemon, weights);
         const pokemonData = pokemonMap[pokemon];
         const shiny = PokemonFactory.generateShiny(GameConstants.SHINY_CHANCE_FARM);
-        const catchChance = PokemonFactory.catchRateHelper(pokemonData.catchRate + 25, true);
+        const catchChance = PokemonFactory.catchRateHelper(pokemonData.catchRate + 25, pokemonData.id, true);
         const wanderer = new WandererPokemon(pokemon, berry.type, catchChance, shiny);
         return wanderer;
     }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -781,6 +781,7 @@ button.btn-circle {
     filter: drop-shadow(0 0 2px #000);
     width: 20px;
 }
+
 .puzzle-medal {
     filter: drop-shadow(0 0 2px #000);
     width: 20px;

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -781,6 +781,10 @@ button.btn-circle {
     filter: drop-shadow(0 0 2px #000);
     width: 20px;
 }
+.puzzle-medal {
+    filter: drop-shadow(0 0 2px #000);
+    width: 20px;
+}
 
 .darker-25 {
     filter: brightness(75%);


### PR DESCRIPTION
## Summary
- add `pokemonPuzzleSolved` stats and show medal on Pokédex entries
- increase catch rate by puzzle bonus
- create puzzle modal, item, and controller skeleton
- expose puzzle controller in the Game class

## Testing
- `npm test` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_684825345e0c8320b8bcd84ee7ad2348